### PR TITLE
feat: make create_link_token send correct request

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.3.0"
+version = "0.2.0"
 authors = ["William Myers <will@telco.in>"]
 edition = "2018"
 description = "Unofficial Rust client library for the Plaid API"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plaid"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["William Myers <will@telco.in>"]
 edition = "2018"
 description = "Unofficial Rust client library for the Plaid API"

--- a/src/lib_futures_01.rs
+++ b/src/lib_futures_01.rs
@@ -114,13 +114,12 @@ impl Client {
     #[allow(dead_code)]
     pub fn create_link_token(
         &self,
+        request: &CreateLinkTokenRequest,
     ) -> impl Future<Item = CreateLinkTokenResponse, Error = ReqwestError> {
-        let body = json!({
-            "client_id": &self.client_id,
-            "secret": &self.secret,
-            "institution_id": "ins_1",
-            "initial_products": ["auth", "identity"]
-        });
+        // TODO: figure out a better way to do this...
+        let mut body = json!(request);
+        body["client_id"] = json!(&self.client_id);
+        body["secret"] = json!(&self.secret);
 
         self.client
             .post(&format!("{}/link/token/create", self.url))

--- a/src/types/token.rs
+++ b/src/types/token.rs
@@ -118,7 +118,7 @@ pub struct CreateLinkTokenRequest {
     /// institutions or accounts shown by the bank in the OAuth window.
     ///
     /// [Account schema]: https://plaid.com/docs/api/accounts#accounts-schema
-    pub account_filters: serde_json::Map<String, serde_json::Value>,
+    pub account_filters: Option<serde_json::Map<String, serde_json::Value>>,
 
     /// Used for supporting legacy custom initializers.
     #[deprecated = "only used for supporting legacy custom initializers"]
@@ -309,7 +309,7 @@ pub struct EndUser {
     /// Typically this will be a user ID number from your application.
     /// Personally identifiable information, such as an email address or phone
     /// number, should not be used in the `client_user_id`.
-    client_user_id: String,
+    pub client_user_id: String,
 }
 
 /// Plaid product supported by Link.


### PR DESCRIPTION
The previous implementation was more of a stub, it didn't send the correct payload even though the `CreateLinkTokenRequest` type was available. This fixes that.