### PR TITLE
feat: parse API errors so they can be handled

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -126,4 +126,8 @@ pub enum ErrorType {
 
     /// Occur when there is an error in OAuth authentication.
     OauthError,
+
+    /// Unknown or all other errors.
+    #[serde(other)]
+    Unknown,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,113 @@
+use std::error::Error as StdError;
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+use reqwest::Error as ReqwestError;
+use serde::Deserialize;
+
+/// Represents an error that can occur when making an API request.
+#[derive(Debug)]
+pub enum Error {
+    /// An error that was reported by the Plaid API
+    Api(ApiError),
+
+    /// An error that ocurred during transport
+    Transport(ReqwestError),
+}
+
+impl From<ReqwestError> for Error {
+    fn from(error: ReqwestError) -> Self {
+        Error::Transport(error)
+    }
+}
+
+impl StdError for Error {}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// See [Error Schema](https://plaid.com/docs/errors/#error-schema)
+#[derive(Debug, Clone, Deserialize)]
+pub struct ApiError {
+    /// A broad categorization of the error. Safe for programatic use.
+    pub error_type: ErrorType,
+
+    /// The particular error code. Safe for programmatic use.
+    pub error_code: String,
+
+    /// A developer-friendly representation of the error code. This may change
+    /// over time and is not safe for programmatic use.
+    pub error_message: String,
+
+    /// A user-friendly representation of the error code. `null` if the error
+    /// is not related to user action. This may change over time and is not
+    /// safe for programmatic use.
+    pub display_message: Option<String>,
+
+    /// A unique ID identifying the request, to be used for troubleshooting
+    /// purposes. This field will be omitted in errors provided by webhooks.
+    pub request_id: Option<String>,
+
+    /// The URL of a Plaid documentation page with more information about the
+    /// error.
+    pub documentation_url: Option<String>,
+
+    /// Suggested steps for resolving the error.
+    pub suggested_action: Option<String>,
+}
+
+/// See [Error Type](https://plaid.com/docs/errors/#Error-error-type)
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ErrorType {
+    /// Occur when an Item may be invalid or not supported on Plaid's platform.
+    ItemError,
+
+    /// Occur when there are errors for the requested financial institution.
+    InstitutionError,
+
+    /// Occur during planned maintenance and in response to API errors.
+    ApiError,
+
+    /// Occur for errors related to Asset endpoints.
+    AssetReportError,
+
+    /// Occur for errors related to Payment Initiation endpoints.
+    PaymentError,
+
+    /// Occur for errors related to Bank Transfers endpoints.
+    BankTransferError,
+
+    /// Occur for errors related to Deposit Switch endpoints.
+    DepositSwitchError,
+
+    /// Occur for errors related to Income endpoints.
+    IncomeVerificationError,
+
+    /// Occur when invalid parameters are supplied in the Sandbox environment.
+    SandboxError,
+
+    /// Occur when a request is malformed and cannot be processed.
+    InvalidRequest,
+
+    /// Occur when all fields are provided, but the values provided are
+    /// incorrect in some way.
+    InvalidInput,
+
+    /// Occur when a request is valid, but the output would be unusable for any
+    /// supported flow.
+    InvalidResult,
+
+    /// Occur when an excessive number of requests are made in a short period
+    /// of time.
+    RateLimitExceeded,
+
+    /// Occur when a Recaptcha challenge has been presented or failed during
+    /// the link process.
+    RecaptchaError,
+
+    /// Occur when there is an error in OAuth authentication.
+    OauthError,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 #[cfg(feature = "futures-std")]
 use reqwest::Error as ReqwestError;
 #[cfg(feature = "futures-01")]
-use reqwest09::Error as ReqwestError;
+use reqwest09::Error as Reqwest09Error;
 use serde::Deserialize;
 
 /// Represents an error that can occur when making an API request.
@@ -13,13 +13,26 @@ pub enum Error {
     /// An error that was reported by the Plaid API
     Api(ApiError),
 
-    /// An error that ocurred during transport
-    Transport(ReqwestError),
+    /// An error that ocurred during transport (using "futures-std" feature)
+    #[cfg(feature = "futures-std")]
+    TransportStd(ReqwestError),
+
+    /// An error that ocurred during transport (using "futures-01" feature)
+    #[cfg(feature = "futures-01")]
+    Transport01(Reqwest09Error),
 }
 
+#[cfg(feature = "futures-std")]
 impl From<ReqwestError> for Error {
     fn from(error: ReqwestError) -> Self {
-        Error::Transport(error)
+        Error::TransportStd(error)
+    }
+}
+
+#[cfg(feature = "futures-01")]
+impl From<Reqwest09Error> for Error {
+    fn from(error: Reqwest09Error) -> Self {
+        Error::Transport01(error)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,10 @@
 use std::error::Error as StdError;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
+#[cfg(feature = "futures-std")]
 use reqwest::Error as ReqwestError;
+#[cfg(feature = "futures-01")]
+use reqwest09::Error as ReqwestError;
 use serde::Deserialize;
 
 /// Represents an error that can occur when making an API request.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,12 +31,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 "##
 )]
 
+pub use self::error::*;
 #[cfg(feature = "futures-01")]
 pub use self::lib_futures_01::*;
 #[cfg(feature = "futures-std")]
 pub use self::lib_futures_std::*;
 pub use self::types::*;
 
+mod error;
 #[cfg(feature = "futures-01")]
 mod lib_futures_01;
 #[cfg(feature = "futures-std")]

--- a/src/lib_futures_01.rs
+++ b/src/lib_futures_01.rs
@@ -8,7 +8,7 @@ use futures01::Future;
 use reqwest09::{r#async::Client as ReqwestClient, StatusCode};
 use serde_json::json;
 
-use crate::{types::*, Error};
+use crate::{error::*, types::*};
 
 // TODO: add `Error` type and improve error handling
 // TODO: make `AccessToken` type to differentiate from `PublicToken` etc.

--- a/src/lib_futures_01.rs
+++ b/src/lib_futures_01.rs
@@ -3,12 +3,12 @@
 use std::env;
 use std::time::Duration;
 
+use futures01::future::{self, Either};
 use futures01::Future;
-use reqwest09::r#async::Client as ReqwestClient;
-use reqwest09::Error as ReqwestError;
+use reqwest09::{r#async::Client as ReqwestClient, StatusCode};
 use serde_json::json;
 
-use crate::types::*;
+use crate::{types::*, Error};
 
 // TODO: add `Error` type and improve error handling
 // TODO: make `AccessToken` type to differentiate from `PublicToken` etc.
@@ -80,7 +80,7 @@ impl Client {
     pub fn sandbox_create_public_token(
         &self,
         request: &SandboxCreatePublicTokenRequest,
-    ) -> impl Future<Item = SandboxCreatePublicTokenResponse, Error = ReqwestError> {
+    ) -> impl Future<Item = SandboxCreatePublicTokenResponse, Error = Error> {
         // TODO: figure out a better way to do this...
         let mut body = json!(request);
         body["client_id"] = json!(&self.client_id);
@@ -90,9 +90,14 @@ impl Client {
             .post(&format!("{}/sandbox/public_token/create", self.url))
             .json(&body)
             .send()
-            .and_then(|res| res.error_for_status())
-            .and_then(|mut res| res.json())
             .from_err()
+            .and_then(|mut res| {
+                let status = res.status();
+                match status {
+                    StatusCode::OK => Either::A(res.json().from_err()),
+                    _ => Either::B(res.json().from_err().map(Error::Api).and_then(future::err)),
+                }
+            })
     }
 
     /// Create Link Token
@@ -115,7 +120,7 @@ impl Client {
     pub fn create_link_token(
         &self,
         request: &CreateLinkTokenRequest,
-    ) -> impl Future<Item = CreateLinkTokenResponse, Error = ReqwestError> {
+    ) -> impl Future<Item = CreateLinkTokenResponse, Error = Error> {
         // TODO: figure out a better way to do this...
         let mut body = json!(request);
         body["client_id"] = json!(&self.client_id);
@@ -125,9 +130,14 @@ impl Client {
             .post(&format!("{}/link/token/create", self.url))
             .json(&body)
             .send()
-            .and_then(|res| res.error_for_status())
-            .and_then(|mut res| res.json())
             .from_err()
+            .and_then(|mut res| {
+                let status = res.status();
+                match status {
+                    StatusCode::OK => Either::A(res.json().from_err()),
+                    _ => Either::B(res.json().from_err().map(Error::Api).and_then(future::err)),
+                }
+            })
     }
 
     /// Exchange a public token for an access token
@@ -149,7 +159,7 @@ impl Client {
     pub fn exchange_public_token(
         &self,
         public_token: &str,
-    ) -> impl Future<Item = ExchangePublicTokenResponse, Error = ReqwestError> {
+    ) -> impl Future<Item = ExchangePublicTokenResponse, Error = Error> {
         // TODO: make this strongly typed?
         let body = json!({
             "client_id": &self.client_id,
@@ -161,9 +171,14 @@ impl Client {
             .post(&format!("{}/item/public_token/exchange", self.url))
             .json(&body)
             .send()
-            .and_then(|res| res.error_for_status())
-            .and_then(|mut res| res.json())
             .from_err()
+            .and_then(|mut res| {
+                let status = res.status();
+                match status {
+                    StatusCode::OK => Either::A(res.json().from_err()),
+                    _ => Either::B(res.json().from_err().map(Error::Api).and_then(future::err)),
+                }
+            })
     }
 
     /// Create processor token
@@ -189,7 +204,7 @@ impl Client {
         access_token: &str,
         account_id: &str,
         processor: SupportedProcessor,
-    ) -> impl Future<Item = CreateProcessorTokenResponse, Error = ReqwestError> {
+    ) -> impl Future<Item = CreateProcessorTokenResponse, Error = Error> {
         // TODO: make this strongly typed?
         let body = json!({
             "client_id": &self.client_id,
@@ -203,9 +218,14 @@ impl Client {
             .post(&format!("{}/processor/token/create", self.url))
             .json(&body)
             .send()
-            .and_then(|res| res.error_for_status())
-            .and_then(|mut res| res.json())
             .from_err()
+            .and_then(|mut res| {
+                let status = res.status();
+                match status {
+                    StatusCode::OK => Either::A(res.json().from_err()),
+                    _ => Either::B(res.json().from_err().map(Error::Api).and_then(future::err)),
+                }
+            })
     }
 
     /// Retrieve accounts
@@ -221,7 +241,7 @@ impl Client {
     pub fn accounts(
         &self,
         access_token: &str,
-    ) -> impl Future<Item = AccountsResponse, Error = ReqwestError> {
+    ) -> impl Future<Item = AccountsResponse, Error = Error> {
         // TODO: make this strongly typed?
         let body = json!({
             "client_id": &self.client_id,
@@ -233,9 +253,14 @@ impl Client {
             .post(&format!("{}/accounts/get", self.url))
             .json(&body)
             .send()
-            .and_then(|res| res.error_for_status())
-            .and_then(|mut res| res.json())
             .from_err()
+            .and_then(|mut res| {
+                let status = res.status();
+                match status {
+                    StatusCode::OK => Either::A(res.json().from_err()),
+                    _ => Either::B(res.json().from_err().map(Error::Api).and_then(future::err)),
+                }
+            })
     }
 
     /// Fetch real-time balance data
@@ -256,7 +281,7 @@ impl Client {
         &self,
         access_token: &str,
         options: BalanceRequestOptions,
-    ) -> impl Future<Item = AccountsResponse, Error = ReqwestError> {
+    ) -> impl Future<Item = AccountsResponse, Error = Error> {
         // TODO: make this strongly typed?
         let body = json!({
             "client_id": &self.client_id,
@@ -269,9 +294,14 @@ impl Client {
             .post(&format!("{}/accounts/balance/get", self.url))
             .json(&body)
             .send()
-            .and_then(|res| res.error_for_status())
-            .and_then(|mut res| res.json())
             .from_err()
+            .and_then(|mut res| {
+                let status = res.status();
+                match status {
+                    StatusCode::OK => Either::A(res.json().from_err()),
+                    _ => Either::B(res.json().from_err().map(Error::Api).and_then(future::err)),
+                }
+            })
     }
 
     /// Fetch auth data
@@ -294,7 +324,7 @@ impl Client {
         &self,
         access_token: &str,
         options: AuthRequestOptions,
-    ) -> impl Future<Item = AuthResponse, Error = ReqwestError> {
+    ) -> impl Future<Item = AuthResponse, Error = Error> {
         // TODO: make this strongly typed?
         let body = json!({
             "client_id": &self.client_id,
@@ -307,9 +337,14 @@ impl Client {
             .post(&format!("{}/auth/get", self.url))
             .json(&body)
             .send()
-            .and_then(|res| res.error_for_status())
-            .and_then(|mut res| res.json())
             .from_err()
+            .and_then(|mut res| {
+                let status = res.status();
+                match status {
+                    StatusCode::OK => Either::A(res.json().from_err()),
+                    _ => Either::B(res.json().from_err().map(Error::Api).and_then(future::err)),
+                }
+            })
     }
 
     /// Fetch identity data
@@ -331,7 +366,7 @@ impl Client {
     pub fn identity(
         &self,
         access_token: &str,
-    ) -> impl Future<Item = AccountsResponse, Error = ReqwestError> {
+    ) -> impl Future<Item = AccountsResponse, Error = Error> {
         // TODO: make this strongly typed?
         let body = json!({
             "client_id": &self.client_id,
@@ -343,9 +378,14 @@ impl Client {
             .post(&format!("{}/identity/get", self.url))
             .json(&body)
             .send()
-            .and_then(|res| res.error_for_status())
-            .and_then(|mut res| res.json())
             .from_err()
+            .and_then(|mut res| {
+                let status = res.status();
+                match status {
+                    StatusCode::OK => Either::A(res.json().from_err()),
+                    _ => Either::B(res.json().from_err().map(Error::Api).and_then(future::err)),
+                }
+            })
     }
 }
 

--- a/src/lib_futures_std.rs
+++ b/src/lib_futures_std.rs
@@ -3,11 +3,11 @@
 use std::env;
 use std::time::Duration;
 
-use reqwest::Client as ReqwestClient;
-use reqwest::Error as ReqwestError;
+use reqwest::{Client as ReqwestClient, StatusCode};
 use serde_json::json;
 
 use crate::types::*;
+use crate::Error;
 
 // TODO: add `Error` type and improve error handling
 // TODO: make `AccessToken` type to differentiate from `PublicToken` etc.
@@ -78,20 +78,23 @@ impl Client {
     pub async fn sandbox_create_public_token(
         &self,
         request: &SandboxCreatePublicTokenRequest,
-    ) -> Result<SandboxCreatePublicTokenResponse, ReqwestError> {
+    ) -> Result<SandboxCreatePublicTokenResponse, Error> {
         // TODO: figure out a better way to do this...
         let mut body = json!(request);
         body["client_id"] = json!(&self.client_id);
         body["secret"] = json!(&self.secret);
 
-        self.client
+        let response = self
+            .client
             .post(&format!("{}/sandbox/public_token/create", self.url))
             .json(&body)
             .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await
+            .await?;
+
+        match response.status() {
+            StatusCode::OK => Ok(response.json().await?),
+            _ => Err(Error::Api(response.json().await?)),
+        }
     }
 
     /// Create Link Token
@@ -114,20 +117,23 @@ impl Client {
     pub async fn create_link_token(
         &self,
         request: &CreateLinkTokenRequest,
-    ) -> Result<CreateLinkTokenResponse, ReqwestError> {
+    ) -> Result<CreateLinkTokenResponse, Error> {
         // TODO: figure out a better way to do this...
         let mut body = json!(request);
         body["client_id"] = json!(&self.client_id);
         body["secret"] = json!(&self.secret);
 
-        self.client
+        let response = self
+            .client
             .post(&format!("{}/link/token/create", self.url))
             .json(&body)
             .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await
+            .await?;
+
+        match response.status() {
+            StatusCode::OK => Ok(response.json().await?),
+            _ => Err(Error::Api(response.json().await?)),
+        }
     }
 
     /// Exchange a public token for an access token
@@ -149,7 +155,7 @@ impl Client {
     pub async fn exchange_public_token(
         &self,
         public_token: &str,
-    ) -> Result<ExchangePublicTokenResponse, ReqwestError> {
+    ) -> Result<ExchangePublicTokenResponse, Error> {
         // TODO: make this strongly typed?
         let body = json!({
             "client_id": &self.client_id,
@@ -157,14 +163,17 @@ impl Client {
             "public_token": public_token,
         });
 
-        self.client
+        let response = self
+            .client
             .post(&format!("{}/item/public_token/exchange", self.url))
             .json(&body)
             .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await
+            .await?;
+
+        match response.status() {
+            StatusCode::OK => Ok(response.json().await?),
+            _ => Err(Error::Api(response.json().await?)),
+        }
     }
 
     /// Create processor token
@@ -190,7 +199,7 @@ impl Client {
         access_token: &str,
         account_id: &str,
         processor: SupportedProcessor,
-    ) -> Result<CreateProcessorTokenResponse, ReqwestError> {
+    ) -> Result<CreateProcessorTokenResponse, Error> {
         // TODO: make this strongly typed?
         let body = json!({
             "client_id": &self.client_id,
@@ -200,14 +209,17 @@ impl Client {
             "processor": processor,
         });
 
-        self.client
+        let response = self
+            .client
             .post(&format!("{}/processor/token/create", self.url))
             .json(&body)
             .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await
+            .await?;
+
+        match response.status() {
+            StatusCode::OK => Ok(response.json().await?),
+            _ => Err(Error::Api(response.json().await?)),
+        }
     }
 
     /// Retrieve accounts
@@ -220,7 +232,7 @@ impl Client {
     ///
     /// [/accounts/get]: https://plaid.com/docs/api/accounts/#accountsget
     #[allow(dead_code)]
-    pub async fn accounts(&self, access_token: &str) -> Result<AccountsResponse, ReqwestError> {
+    pub async fn accounts(&self, access_token: &str) -> Result<AccountsResponse, Error> {
         // TODO: make this strongly typed?
         let body = json!({
             "client_id": &self.client_id,
@@ -228,14 +240,17 @@ impl Client {
             "access_token": access_token,
         });
 
-        self.client
+        let response = self
+            .client
             .post(&format!("{}/accounts/get", self.url))
             .json(&body)
             .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await
+            .await?;
+
+        match response.status() {
+            StatusCode::OK => Ok(response.json().await?),
+            _ => Err(Error::Api(response.json().await?)),
+        }
     }
 
     /// Fetch real-time balance data
@@ -256,7 +271,7 @@ impl Client {
         &self,
         access_token: &str,
         options: BalanceRequestOptions,
-    ) -> Result<AccountsResponse, ReqwestError> {
+    ) -> Result<AccountsResponse, Error> {
         // TODO: make this strongly typed?
         let body = json!({
             "client_id": &self.client_id,
@@ -265,14 +280,17 @@ impl Client {
             "options": options,
         });
 
-        self.client
+        let response = self
+            .client
             .post(&format!("{}/accounts/balance/get", self.url))
             .json(&body)
             .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await
+            .await?;
+
+        match response.status() {
+            StatusCode::OK => Ok(response.json().await?),
+            _ => Err(Error::Api(response.json().await?)),
+        }
     }
 
     /// Fetch auth data
@@ -295,7 +313,7 @@ impl Client {
         &self,
         access_token: &str,
         options: AuthRequestOptions,
-    ) -> Result<AuthResponse, ReqwestError> {
+    ) -> Result<AuthResponse, Error> {
         // TODO: make this strongly typed?
         let body = json!({
             "client_id": &self.client_id,
@@ -304,14 +322,17 @@ impl Client {
             "options": options,
         });
 
-        self.client
+        let response = self
+            .client
             .post(&format!("{}/auth/get", self.url))
             .json(&body)
             .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await
+            .await?;
+
+        match response.status() {
+            StatusCode::OK => Ok(response.json().await?),
+            _ => Err(Error::Api(response.json().await?)),
+        }
     }
 
     /// Fetch identity data
@@ -330,7 +351,7 @@ impl Client {
     ///
     /// [/identity/get]: https://plaid.com/docs/api/products/#identityget
     #[allow(dead_code)]
-    pub async fn identity(&self, access_token: &str) -> Result<AccountsResponse, ReqwestError> {
+    pub async fn identity(&self, access_token: &str) -> Result<AccountsResponse, Error> {
         // TODO: make this strongly typed?
         let body = json!({
             "client_id": &self.client_id,
@@ -338,14 +359,17 @@ impl Client {
             "access_token": access_token,
         });
 
-        self.client
+        let response = self
+            .client
             .post(&format!("{}/identity/get", self.url))
             .json(&body)
             .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await
+            .await?;
+
+        match response.status() {
+            StatusCode::OK => Ok(response.json().await?),
+            _ => Err(Error::Api(response.json().await?)),
+        }
     }
 }
 


### PR DESCRIPTION
The quick-and-easy Reqwest `error_for_status()` function only keeps the
endpoint and status code. This is inadequate for diagnosing specific
errors since many will fall under the same status code.

This makes the client requests properly parse and return Plaid-specific
errors so they can be logged, inspected, and handled.

Old error:
```
Error(
    Status(
        400,
    ),
    "https://sandbox.plaid.com/sandbox/public_token/create",
)
```

New error:
```
ApiError {
    error_type: InvalidRequest,
    error_code: "INVALID_FIELD",
    error_message: "client_id must be a properly formatted, non-empty string",
    display_message: None,
    request_id: Some(
        "OSyLPaAMzjqQS9X",
    ),
    documentation_url: Some(
        "https://plaid.com/docs/?ref=error#invalid-request-errors",
    ),
    suggested_action: None,
}
```